### PR TITLE
Moved echoing of output outside if statement

### DIFF
--- a/docker-args
+++ b/docker-args
@@ -6,6 +6,7 @@ APP="$1"
 LINK_FILE="LINK"
 LINK_FILE_PATH="$DOKKU_ROOT/$APP/$LINK_FILE"
 
+output=""
 if [[ -f "$LINK_FILE_PATH" ]]; then
   while read line
   do


### PR DESCRIPTION
Closes #3 - ensures plugin echoes `$output` even if it doesn't have anything to add to it
