### PR TITLE
Return $DOKKU_NOT_IMPLEMENTED_EXIT when an unsupported command is called.

### DIFF
--- a/commands
+++ b/commands
@@ -86,4 +86,8 @@ case "$1" in
 EOF
   ;;
 
+  *)
+    exit $DOKKU_NOT_IMPLEMENTED_EXIT
+  ;;
+
 esac


### PR DESCRIPTION
Please note that such return code has been introduced in dokku with the commit d307a5b8.

Thanks for considering.